### PR TITLE
fix bug issue#36

### DIFF
--- a/spring-cloud-huawei-servicecomb-discovery/src/main/java/org.springframework.cloud.servicecomb.discovery/client/model/ServiceRegistryConfig.java
+++ b/spring-cloud-huawei-servicecomb-discovery/src/main/java/org.springframework.cloud.servicecomb.discovery/client/model/ServiceRegistryConfig.java
@@ -34,7 +34,7 @@ public final class ServiceRegistryConfig {
 
   public static final String DEFAULT_APPID = "default";
 
-  public static final String DEFAULT_CALL_VERSION = "latest";
+  public static final String DEFAULT_CALL_VERSION = "0.0.0+";
 
   public static final int DEFAULT_HEALTHCHECK_INTERVAL = 10;
 


### PR DESCRIPTION
rule：
1  Exact match, e.g: 0.0.1
2  Subsequent version matching, e.g: 0.0.1+
3  Latest version matching, e.g: latest
4  Version range matching, e.g: 0.1.0-0.2.0