### PR TITLE
bugfix , avoid error log

### DIFF
--- a/spring-cloud-huawei-common/src/main/java/com/huaweicloud/common/auth/AuthHeaderStrategyMount.java
+++ b/spring-cloud-huawei-common/src/main/java/com/huaweicloud/common/auth/AuthHeaderStrategyMount.java
@@ -43,11 +43,11 @@ public class AuthHeaderStrategyMount extends AuthHeaderStrategy {
 
   public AuthHeaderStrategyMount() {
     try {
-      WatchService watchService = FileSystems.getDefault().newWatchService();
       Path p = Paths.get(DEFAULT_SECRET_AUTH_PATH);
       if (!p.toFile().exists()) {
         return;
       }
+      WatchService watchService = FileSystems.getDefault().newWatchService();
       p.register(watchService,
           StandardWatchEventKinds.ENTRY_MODIFY,
           StandardWatchEventKinds.ENTRY_CREATE);

--- a/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/RouterWebMvcConfigurer.java
+++ b/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/RouterWebMvcConfigurer.java
@@ -51,7 +51,7 @@ public class RouterWebMvcConfigurer implements WebMvcConfigurer {
   }
 
   @Bean
-  @ConditionalOnProperty(prefix = "servicecomb.router.hystrix", havingValue = "true", matchIfMissing = true)
+  @ConditionalOnProperty(value = "servicecomb.router.hystrix.enabled", matchIfMissing = true)
   public RouterHystrixConcurrencyStrategy routerHystrixConcurrencyStrategy() {
     return new RouterHystrixConcurrencyStrategy();
   }

--- a/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/ribbon/RouterLoadBalanceRule.java
+++ b/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/ribbon/RouterLoadBalanceRule.java
@@ -35,7 +35,7 @@ public class RouterLoadBalanceRule extends ZoneAvoidanceRule {
   @Override
   public Server choose(Object key) {
     List<Server> serverList = RouterFilter
-        .getFilteredListOfServers(getLoadBalancer().getAllServers(),
+        .getFilteredListOfServers(getLoadBalancer().getReachableServers(),
             RouterTrackContext.getServiceName(),
             RouterTrackContext.getRequestHeader(),
             distributor);

--- a/spring-cloud-huawei-router-core/src/main/java/com/huaweicloud/router/core/model/TagItem.java
+++ b/spring-cloud-huawei-router-core/src/main/java/com/huaweicloud/router/core/model/TagItem.java
@@ -120,10 +120,14 @@ public class TagItem {
     if(version != null && !version.equals(item.version)){
       return 0;
     }
+    cnt++;
     for (Map.Entry<String, String> entry : param.entrySet()) {
       if (item.getParam().containsKey(entry.getKey()) &&
           !item.getParam().get(entry.getKey()).equals(entry.getValue())) {
         return 0;
+      }
+      if (!item.getParam().containsKey(entry.getKey())) {
+        continue;
       }
       cnt++;
     }

--- a/spring-cloud-huawei-servicecomb-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/MicroserviceHandler.java
+++ b/spring-cloud-huawei-servicecomb-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/MicroserviceHandler.java
@@ -17,6 +17,7 @@
 
 package com.huaweicloud.servicecomb.discovery.discovery;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -43,6 +44,8 @@ public class MicroserviceHandler {
 
   public static final Map<String, String> serviceRevision = new ConcurrentHashMap<>();
 
+  public static final Map<String, List<ServiceInstance>> discoveryServerList = new ConcurrentHashMap<>();
+
   public static List<ServiceInstance> getInstances(Microservice microservice, ServiceCombClient serviceCombClient) {
     try {
       String revision = "0";
@@ -50,6 +53,12 @@ public class MicroserviceHandler {
         revision = serviceRevision.get(microservice.getServiceName());
       }
       instanceList = serviceCombClient.getInstances(microservice, revision);
+      if (instanceList.isEmpty()) {
+        instanceList = discoveryServerList
+            .getOrDefault(microservice.getServiceName(), new ArrayList<>());
+      } else {
+        discoveryServerList.put(microservice.getServiceName(), instanceList);
+      }
     } catch (ServiceCombException e) {
       LOGGER.warn("get instances failed.", e);
     }

--- a/spring-cloud-huawei-servicecomb-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/ServiceCombDiscoveryProperties.java
+++ b/spring-cloud-huawei-servicecomb-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/ServiceCombDiscoveryProperties.java
@@ -38,7 +38,7 @@ public class ServiceCombDiscoveryProperties {
 
   private String appName;
 
-  @Value("${spring.cloud.servicecomb.discovery.serviceName:${spring.application.name}}")
+  @Value("${spring.cloud.servicecomb.discovery.serviceName:${spring.application.name:}}")
   private String serviceName;
 
   @Value("${server.env:}")

--- a/spring-cloud-huawei-servicecomb-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/ribbon/ServiceCombIPing.java
+++ b/spring-cloud-huawei-servicecomb-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/ribbon/ServiceCombIPing.java
@@ -1,0 +1,24 @@
+package com.huaweicloud.servicecomb.discovery.ribbon;
+
+import com.netflix.loadbalancer.IPing;
+import com.netflix.loadbalancer.Server;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+/**
+ * @Author GuoYl123
+ * @Date 2020/4/17
+ **/
+public class ServiceCombIPing implements IPing {
+
+  @Override
+  public boolean isAlive(Server server) {
+    try (Socket s = new Socket()) {
+      s.connect(new InetSocketAddress(server.getHost(), server.getPort()), 3000);
+    } catch (IOException e) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/spring-cloud-huawei-servicecomb-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/ribbon/ServiceCombRibbonClientConfiguration.java
+++ b/spring-cloud-huawei-servicecomb-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/ribbon/ServiceCombRibbonClientConfiguration.java
@@ -17,6 +17,7 @@
 
 package com.huaweicloud.servicecomb.discovery.ribbon;
 
+import com.netflix.loadbalancer.IPing;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import com.huaweicloud.servicecomb.discovery.discovery.ServiceCombDiscoveryProperties;
 import org.springframework.context.annotation.Bean;
@@ -40,5 +41,10 @@ public class ServiceCombRibbonClientConfiguration {
     ServiceCombServerList serverList = new ServiceCombServerList(serviceCombProperties);
     serverList.initWithNiwsConfig(config);
     return serverList;
+  }
+
+  @Bean
+  public IPing ping() {
+    return new ServiceCombIPing();
   }
 }

--- a/spring-cloud-huawei-servicecomb-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/ribbon/ServiceCombServerList.java
+++ b/spring-cloud-huawei-servicecomb-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/ribbon/ServiceCombServerList.java
@@ -18,7 +18,6 @@
 package com.huaweicloud.servicecomb.discovery.ribbon;
 
 import com.huaweicloud.servicecomb.discovery.client.model.MicroserviceInstanceStatus;
-import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.Server;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,9 +41,6 @@ public class ServiceCombServerList extends AbstractServerList<Server> {
 
   @Autowired
   private ServiceCombClient serviceCombClient;
-
-  @Autowired
-  private ILoadBalancer loadBalancer;
 
   private ServiceCombDiscoveryProperties serviceCombDiscoveryProperties;
 
@@ -72,9 +68,6 @@ public class ServiceCombServerList extends AbstractServerList<Server> {
     //spring cloud serviceId equals servicecomb serviceName
     List<ServiceInstance> instanceList = MicroserviceHandler
         .getInstances(microService, serviceCombClient);
-    if (instanceList.isEmpty()) {
-      return loadBalancer.getAllServers();
-    }
     return transform(instanceList);
   }
 

--- a/spring-cloud-huawei-servicecomb-discovery/src/test/java/com/huaweicloud/servicecomb/discovery/ribbon/ServiceCombServerListTest.java
+++ b/spring-cloud-huawei-servicecomb-discovery/src/test/java/com/huaweicloud/servicecomb/discovery/ribbon/ServiceCombServerListTest.java
@@ -19,7 +19,6 @@ package com.huaweicloud.servicecomb.discovery.ribbon;
 
 import com.huaweicloud.servicecomb.discovery.client.model.MicroserviceInstanceStatus;
 import com.huaweicloud.servicecomb.discovery.discovery.ServiceCombDiscoveryProperties;
-import com.netflix.loadbalancer.BaseLoadBalancer;
 import com.netflix.loadbalancer.Server;
 import java.net.URI;
 import java.util.ArrayList;
@@ -54,9 +53,6 @@ public class ServiceCombServerListTest {
 
   @Injectable
   ServiceCombDiscoveryProperties serviceCombDiscoveryProperties;
-
-  @Injectable
-  BaseLoadBalancer baseLoadBalancer;
 
   @Injectable
   IClientConfig iClientConfig;


### PR DESCRIPTION
bugfix:
1. current master exsit a bug that make consumer print tons of error  log when invoke a unavailable instance.
2. router choose allserver may containe unavailable instance.
2. router tags match bug.
3. if cann't find iam info file, no need to open new watchers.