### PR TITLE
feat: proxyBeanMethods false 提高性能 & 统一编辑器规则

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root=true
+
+[*.{groovy,java,kt,xml}]
+indent_style = tab
+indent_size = 4
+continuation_indent_size = 8

--- a/spring-cloud-huawei-swagger/src/main/java/com/huaweicloud/swagger/SwaggerConfiguration.java
+++ b/spring-cloud-huawei-swagger/src/main/java/com/huaweicloud/swagger/SwaggerConfiguration.java
@@ -26,7 +26,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
  * @Author GuoYl123
  * @Date 2019/12/17
  **/
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @EnableSwagger2
 public class SwaggerConfiguration {
 


### PR DESCRIPTION
1. Since spring boot 2.1 (spring 5.2) provided proxyBeanMethods attribute , It is recommended to add this attribute to all beans that have no reference relationship.You can see this spring-boot-starter, I only need swagger, I only dealt with here.

2. The code editor rules are strange with two spaces?Added spring boot official code editor rules

3.  Finally, it is recommended to add the formatting tool of the spring specification

```
<profile>
		  <id>default</id>
		  <build>
			  <plugins>
				  <plugin>
					  <groupId>io.spring.javaformat</groupId>
					  <artifactId>spring-javaformat-maven-plugin</artifactId>
					  <version>0.0.22</version>
				  </plugin>
			  </plugins>
		  </build>
	  </profile>
```

```
 mvn spring-javaformat:apply
```
![](http://pigx.vip/20200615160217_YIq3KL_Screenshot.jpeg)


Come on! Graduate early
