### PR TITLE
[#409] find latest version tag every time

### DIFF
--- a/spring-cloud-huawei-router-core/src/main/java/com/huaweicloud/router/core/distribute/AbstractRouterDistributor.java
+++ b/spring-cloud-huawei-router-core/src/main/java/com/huaweicloud/router/core/distribute/AbstractRouterDistributor.java
@@ -127,9 +127,6 @@ public abstract class AbstractRouterDistributor<T extends Server> implements
   }
 
   public void initLatestVersion(String serviceName, List<T> list) {
-    if (RouterRuleCache.getServiceInfoCacheMap().get(serviceName).getLatestVersionTag() != null) {
-      return;
-    }
     String latestVersion = null;
     for (T item : list) {
       ServiceCombServer server = (ServiceCombServer) item;


### PR DESCRIPTION
to avoid the circumstance that the latest version in cache is deleted so that sdk cannot find it, we do not read the old cached version tag, and refind the latest version every time.