### PR TITLE
[#583] Fixed one Bug to demonstate the function of SpotBugs and its setting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,38 @@
           </excludes>
         </configuration>
       </plugin>
+      <!--SpotBugs-->
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.5.2.0</version>
+        <dependencies>
+          <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+          <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>4.5.3</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <!--Analysis Effort-->
+          <effort>Max</effort>
+          <!--Minimun Condidence-->
+          <threshold>Medium</threshold>
+          <!--Minimum Rank-->
+          <maxRank>20</maxRank>
+          <!--          <includeFilterFile>spotbugs-security/spotbugs-security-include.xml</includeFilterFile>-->
+          <excludeFilterFile>spotbugs-security/spotbugs-security-exclude.xml</excludeFilterFile>
+          <includeTests>false</includeTests>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,6 @@
       </modules>
     </profile>
   </profiles>
-
   <build>
     <pluginManagement>
       <plugins>
@@ -184,6 +183,7 @@
           </execution>
         </executions>
       </plugin>
+      
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
@@ -205,7 +205,14 @@
             <!--Exclude the directories you don't want to check, but it only works for sub modules. Please refer to the following example-->
             <exclude>**/com/huaweicloud/sample/**</exclude>
             <exclude>**/com/huaweicloud/samples/**</exclude>
-          </excludes>
+          </excludes>            
+         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
           <execution>
             <id>aggregate</id>
             <goals>
@@ -217,6 +224,9 @@
             </configuration>
             <phase>site</phase>
           </execution>
+         </execution>
+        </executions>
+      </plugin>                 
     </plugins>
   </build>
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>4.5.2.0</version>
         <dependencies>
-          <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+          <!--overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
@@ -172,7 +172,7 @@
           <threshold>Medium</threshold>
           <!--Minimum Rank-->
           <maxRank>20</maxRank>
-          <!--          <includeFilterFile>spotbugs-security/spotbugs-security-include.xml</includeFilterFile>-->
+          <!--<includeFilterFile>spotbugs-security/spotbugs-security-include.xml</includeFilterFile>-->
           <excludeFilterFile>spotbugs-security/spotbugs-security-exclude.xml</excludeFilterFile>
           <includeTests>false</includeTests>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,6 @@
           <!--          <includeFilterFile>spotbugs-security/spotbugs-security-include.xml</includeFilterFile>-->
           <excludeFilterFile>spotbugs-security/spotbugs-security-exclude.xml</excludeFilterFile>
           <includeTests>false</includeTests>
-          >>>>>>> master
         </configuration>
         <executions>
           <execution>

--- a/spotbugs-security/spotbugs-security-exclude.xml
+++ b/spotbugs-security/spotbugs-security-exclude.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <!-- All bugs in test classes, except for JUnit-specific bugs -->
+    <Match>
+    <Class name="~.*\.*Test" />
+    </Match>
+
+    <Match>
+        <Class name="~.*\.Test*" />
+    </Match>
+
+    <Match>
+    <Package name="integration-tests"/>
+    </Match>
+
+    <Match>
+        <Bug category="I18N"/>
+    </Match>
+
+    <Match>
+        <Bug category="MALICIOUS_CODE"/>
+    </Match>
+
+    <Match>
+        <Bug category="STYLE"/>
+    </Match>
+
+</FindBugsFilter>

--- a/spotbugs-security/spotbugs-security-include.xml
+++ b/spotbugs-security/spotbugs-security-include.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+</FindBugsFilter>

--- a/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/track/RouterWebAutoConfiguration.java
+++ b/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/track/RouterWebAutoConfiguration.java
@@ -37,7 +37,7 @@ import feign.RequestInterceptor;
 public class RouterWebAutoConfiguration {
   @Configuration
   @ConditionalOnClass(WebMvcConfigurer.class)
-  class WebMvcConfigurerEnable {
+  static class WebMvcConfigurerEnable {
     @Bean
     public WebMvcConfigurer canaryWebMvcConfigurer() {
       return new WebMvcConfigurer() {


### PR DESCRIPTION
This PR is to show demonstrate how to set the setting of SpotBugs. This PR's setting is almost the same as the last PR, but it adds three types of Bugs and will not report in the report state. the extra setting is below
(below show three elements that been set in the excludefilefilter.xml and it means dont report the the nested bugs (bind with their abbreviations) )
  ``` 
    <Match> 
        <Bug category="I18N"/>
    </Match>

    <Match>
        <Bug category="MALICIOUS_CODE"/>
    </Match>

    <Match>
        <Bug category="STYLE"/>
    </Match>

It stills has  one type of Bugs  which  is  SIC_INNER _SHOULD_BE_STATIC ,  so  it needs to modify the  WebMvcConfigurerEnable  as  a  static inner class.  After the repair,  the CI  will  success.  We can achieved  it by change the five dimensions if project need to show more Bugs .