### PR TITLE
[#592]Gateway supports HTTPS.

### DIFF
--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/client/model/ServiceCombServiceInstance.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/client/model/ServiceCombServiceInstance.java
@@ -18,20 +18,13 @@
 package com.huaweicloud.servicecomb.discovery.client.model;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.servicecomb.foundation.common.net.URIEndpointObject;
 import org.apache.servicecomb.service.center.client.model.MicroserviceInstance;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.cloud.client.ServiceInstance;
 
 public class ServiceCombServiceInstance implements ServiceInstance {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ServiceCombServiceInstance.class);
-
   private final URIEndpointObject uriEndpointObject;
 
   private final MicroserviceInstance microserviceInstance;

--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/client/model/ServiceCombServiceInstance.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/client/model/ServiceCombServiceInstance.java
@@ -87,20 +87,9 @@ public class ServiceCombServiceInstance implements ServiceInstance {
 
   @Override
   public URI getUri() {
-    String endpoint = this.microserviceInstance.getEndpoints().stream().filter(e -> e.startsWith("rest://"))
-            .findFirst().orElse(null);
-
-    if (endpoint == null) {
-      return null;
-    }
-
-    URI uri = null;
-    try {
-      uri = new URIBuilder(endpoint).build();
-    } catch (URISyntaxException e) {
-      LOGGER.error("invalid instance endpoint [{}]", endpoint);
-    }
-    return uri;
+    String scheme = this.getScheme();
+    String uri = String.format("%s://%s:%s", scheme, uriEndpointObject.getHostOrIp(), uriEndpointObject.getPort());
+    return URI.create(uri);
   }
 
   @Override

--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/client/model/ServiceCombServiceInstance.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/client/model/ServiceCombServiceInstance.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.servicecomb.foundation.common.net.URIEndpointObject;
 import org.apache.servicecomb.service.center.client.model.MicroserviceInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,8 +89,8 @@ public class ServiceCombServiceInstance implements ServiceInstance {
 
   @Override
   public boolean isSecure() {
-    // TODO: add secure implementation
-    return false;
+    URIEndpointObject uriEndpointObject = new URIEndpointObject(this.microserviceInstance.getEndpoints().get(0));
+    return uriEndpointObject.isSslEnabled();
   }
 
   @Override

--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/client/model/ServiceCombServiceInstance.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/client/model/ServiceCombServiceInstance.java
@@ -32,10 +32,13 @@ import org.springframework.cloud.client.ServiceInstance;
 public class ServiceCombServiceInstance implements ServiceInstance {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServiceCombServiceInstance.class);
 
+  private final URIEndpointObject uriEndpointObject;
+
   private final MicroserviceInstance microserviceInstance;
 
   public ServiceCombServiceInstance(MicroserviceInstance microserviceInstance) {
     this.microserviceInstance = microserviceInstance;
+    this.uriEndpointObject = new URIEndpointObject(this.microserviceInstance.getEndpoints().get(0));
   }
 
   public MicroserviceInstance getMicroserviceInstance() {
@@ -54,11 +57,7 @@ public class ServiceCombServiceInstance implements ServiceInstance {
 
   @Override
   public String getHost() {
-    URI uri = parseEndpoint();
-    if (uri == null) {
-      return this.microserviceInstance.getInstanceId(); // compatible to ribbon default host name
-    }
-    return uri.getHost();
+    return uriEndpointObject.getHostOrIp();
   }
 
   private URI parseEndpoint() {
@@ -80,16 +79,11 @@ public class ServiceCombServiceInstance implements ServiceInstance {
 
   @Override
   public int getPort() {
-    URI uri = parseEndpoint();
-    if (uri == null) {
-      return 0;
-    }
-    return uri.getPort();
+    return uriEndpointObject.getPort();
   }
 
   @Override
   public boolean isSecure() {
-    URIEndpointObject uriEndpointObject = new URIEndpointObject(this.microserviceInstance.getEndpoints().get(0));
     return uriEndpointObject.isSslEnabled();
   }
 
@@ -113,7 +107,6 @@ public class ServiceCombServiceInstance implements ServiceInstance {
 
   @Override
   public String getScheme() {
-    // TODO: add schema implementation
-    return null;
+    return uriEndpointObject.isSslEnabled() ? "https" : "http";
   }
 }

--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/DiscoveryProperties.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/DiscoveryProperties.java
@@ -25,11 +25,22 @@ public class DiscoveryProperties {
   @Value("${server.port}")
   private String port;
 
+  @Value("${server.ssl.enabled:false}")
+  private String sslEnabled;
+
   public String getPort() {
     return port;
   }
 
   public void setPort(String port) {
     this.port = port;
+  }
+
+  public String getSslEnabled() {
+    return sslEnabled;
+  }
+
+  public void setSslEnabled(String sslEnabled) {
+    this.sslEnabled = sslEnabled;
   }
 }

--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/DiscoveryProperties.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/DiscoveryProperties.java
@@ -26,7 +26,7 @@ public class DiscoveryProperties {
   private String port;
 
   @Value("${server.ssl.enabled:false}")
-  private String sslEnabled;
+  private Boolean sslEnabled;
 
   public String getPort() {
     return port;
@@ -36,11 +36,11 @@ public class DiscoveryProperties {
     this.port = port;
   }
 
-  public String getSslEnabled() {
+  public Boolean getSslEnabled() {
     return sslEnabled;
   }
 
-  public void setSslEnabled(String sslEnabled) {
+  public void setSslEnabled(Boolean sslEnabled) {
     this.sslEnabled = sslEnabled;
   }
 }

--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/DiscoveryProperties.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/DiscoveryProperties.java
@@ -36,7 +36,7 @@ public class DiscoveryProperties {
     this.port = port;
   }
 
-  public Boolean getSslEnabled() {
+  public Boolean isSslEnabled() {
     return sslEnabled;
   }
 

--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/MicroserviceHandler.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/MicroserviceHandler.java
@@ -114,8 +114,8 @@ public class MicroserviceHandler {
     } else {
       address = discoveryBootstrapProperties.getServerAddress();
     }
-    if (discoveryProperties.getSslEnabled()) {
-        endPoints.add("rest://" + address + ":" + discoveryProperties.getPort() + "?sslEnabled=" + discoveryProperties.getSslEnabled());
+    if (discoveryProperties.isSslEnabled()) {
+        endPoints.add("rest://" + address + ":" + discoveryProperties.getPort() + "?sslEnabled=" + discoveryProperties.isSslEnabled());
     } else {
         endPoints.add("rest://" + address + ":" + discoveryProperties.getPort());
     }

--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/MicroserviceHandler.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/MicroserviceHandler.java
@@ -114,9 +114,8 @@ public class MicroserviceHandler {
     } else {
       address = discoveryBootstrapProperties.getServerAddress();
     }
-    boolean sslEnabled = Boolean.parseBoolean(discoveryProperties.getSslEnabled());
-    if (sslEnabled) {
-        endPoints.add("rest://" + address + ":" + discoveryProperties.getPort() + "?sslEnabled=" + sslEnabled);
+    if (discoveryProperties.getSslEnabled()) {
+        endPoints.add("rest://" + address + ":" + discoveryProperties.getPort() + "?sslEnabled=" + discoveryProperties.getSslEnabled());
     } else {
         endPoints.add("rest://" + address + ":" + discoveryProperties.getPort());
     }

--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/MicroserviceHandler.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/MicroserviceHandler.java
@@ -114,7 +114,7 @@ public class MicroserviceHandler {
     } else {
       address = discoveryBootstrapProperties.getServerAddress();
     }
-    endPoints.add("rest://" + address + ":" + discoveryProperties.getPort());
+    endPoints.add("rest://" + address + ":" + discoveryProperties.getPort()+"?sslEnabled="+discoveryProperties.getSslEnabled());
     microserviceInstance.setEndpoints(endPoints);
     HealthCheck healthCheck = new HealthCheck();
     healthCheck.setMode(HealthCheckMode.pull);

--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/MicroserviceHandler.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/MicroserviceHandler.java
@@ -114,7 +114,12 @@ public class MicroserviceHandler {
     } else {
       address = discoveryBootstrapProperties.getServerAddress();
     }
-    endPoints.add("rest://" + address + ":" + discoveryProperties.getPort()+"?sslEnabled="+discoveryProperties.getSslEnabled());
+    boolean sslEnabled = Boolean.parseBoolean(discoveryProperties.getSslEnabled());
+    if (sslEnabled) {
+        endPoints.add("rest://" + address + ":" + discoveryProperties.getPort() + "?sslEnabled=" + sslEnabled);
+    } else {
+        endPoints.add("rest://" + address + ":" + discoveryProperties.getPort());
+    }
     microserviceInstance.setEndpoints(endPoints);
     HealthCheck healthCheck = new HealthCheck();
     healthCheck.setMode(HealthCheckMode.pull);


### PR DESCRIPTION
#592 修复此问题
通过application.yml中配置`server.ssl.enabled: true`开启https路由
ssl证书的配置可参考下图
![image](https://user-images.githubusercontent.com/28680878/159636431-1a9601ef-029e-4fa9-b954-cb381485003b.png)