### PR TITLE
[#632] support healtch check if registratioin is ready with actuator

### DIFF
--- a/spring-cloud-huawei-bom/pom.xml
+++ b/spring-cloud-huawei-bom/pom.xml
@@ -37,6 +37,11 @@
       <!-- this project -->
       <dependency>
         <groupId>com.huaweicloud</groupId>
+        <artifactId>spring-cloud-starter-huawei-actuator</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.huaweicloud</groupId>
         <artifactId>spring-cloud-huawei-discovery</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/spring-cloud-starter-huawei/pom.xml
+++ b/spring-cloud-starter-huawei/pom.xml
@@ -38,6 +38,7 @@
     <module>spring-cloud-starter-huawei-service-engine-gateway</module>
     <module>spring-cloud-starter-huawei-jasypt</module>
     <module>spring-cloud-starter-huawei-hessian</module>
+    <module>spring-cloud-starter-huawei-actuator</module>
   </modules>
 
 </project>

--- a/spring-cloud-starter-huawei/spring-cloud-starter-huawei-actuator/pom.xml
+++ b/spring-cloud-starter-huawei/spring-cloud-starter-huawei-actuator/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.huaweicloud</groupId>
         <artifactId>spring-cloud-starter-huawei</artifactId>
-        <version>1.9.0-2020.0.x-SNAPSHOT</version>
+        <version>1.9.0-Hoxton-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-cloud-starter-huawei-actuator</artifactId>

--- a/spring-cloud-starter-huawei/spring-cloud-starter-huawei-actuator/pom.xml
+++ b/spring-cloud-starter-huawei/spring-cloud-starter-huawei-actuator/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  ~ Copyright (C) 2020-2022 Huawei Technologies Co., Ltd. All rights reserved.
+
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.huaweicloud</groupId>
+        <artifactId>spring-cloud-starter-huawei</artifactId>
+        <version>1.9.0-2020.0.x-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>spring-cloud-starter-huawei-actuator</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud</groupId>
+            <artifactId>spring-cloud-huawei-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spring-cloud-starter-huawei/spring-cloud-starter-huawei-actuator/src/main/java/com/huaweicloud/health/check/RegistryHealthIndicator.java
+++ b/spring-cloud-starter-huawei/spring-cloud-starter-huawei-actuator/src/main/java/com/huaweicloud/health/check/RegistryHealthIndicator.java
@@ -1,0 +1,48 @@
+/*
+
+ * Copyright (C) 2020-2022 Huawei Technologies Co., Ltd. All rights reserved.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.health.check;
+
+import com.google.common.eventbus.Subscribe;
+import com.huaweicloud.common.event.EventManager;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.apache.servicecomb.service.center.client.RegistrationEvents.MicroserviceRegistrationEvent;
+
+public class RegistryHealthIndicator implements HealthIndicator {
+
+    private boolean isSuccess = false;
+
+    private static final String REGISTRATION_NOT_READY = "registration not ready";
+
+    public RegistryHealthIndicator() {
+        EventManager.register(this);
+    }
+
+    @Override
+    public Health health() {
+        if (isSuccess) {
+            return Health.up().build();
+        }
+        return Health.down().withDetail("Error Message", REGISTRATION_NOT_READY).build();
+    }
+
+    @Subscribe
+    public void registryListener(MicroserviceRegistrationEvent event) {
+            this.isSuccess = event.isSuccess();
+    }
+}

--- a/spring-cloud-starter-huawei/spring-cloud-starter-huawei-actuator/src/main/java/com/huaweicloud/health/check/RegistryHealthIndicatorConfiguration.java
+++ b/spring-cloud-starter-huawei/spring-cloud-starter-huawei-actuator/src/main/java/com/huaweicloud/health/check/RegistryHealthIndicatorConfiguration.java
@@ -1,0 +1,32 @@
+/*
+
+ * Copyright (C) 2020-2022 Huawei Technologies Co., Ltd. All rights reserved.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.health.check;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
+@Configuration
+public class RegistryHealthIndicatorConfiguration {
+
+    @Bean
+    @Order(100)
+    public RegistryHealthIndicator registryHealthIndicator() {
+         return new RegistryHealthIndicator();
+    }
+}

--- a/spring-cloud-starter-huawei/spring-cloud-starter-huawei-actuator/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-starter-huawei/spring-cloud-starter-huawei-actuator/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.huaweicloud.health.check.RegistryHealthIndicatorConfiguration


### PR DESCRIPTION
From: #632 
Override the health interface in the Actuator so that it returns to the Up state only after the microservice is successfully registered.