### PR TITLE
mark field final

### DIFF
--- a/integration-tests/cse-v1/consumer/src/main/java/com/huaweicloud/samples/ConsumerConfigController.java
+++ b/integration-tests/cse-v1/consumer/src/main/java/com/huaweicloud/samples/ConsumerConfigController.java
@@ -28,9 +28,9 @@ import java.util.List;
 @RestController
 public class ConsumerConfigController {
 
-  private Environment environment;
+  private final Environment environment;
 
-  private ConsumerConfigurationProperties consumerConfigurationProperties;
+  private final ConsumerConfigurationProperties consumerConfigurationProperties;
 
   @Autowired
   public ConsumerConfigController(Environment environment, ConsumerConfigurationProperties consumerConfigurationProperties) {

--- a/integration-tests/cse-v1/consumer/src/main/java/com/huaweicloud/samples/ConsumerController.java
+++ b/integration-tests/cse-v1/consumer/src/main/java/com/huaweicloud/samples/ConsumerController.java
@@ -26,7 +26,7 @@ import org.springframework.web.client.RestTemplate;
 @RestController
 public class ConsumerController {
 
-  private RestTemplate restTemplate;
+  private final RestTemplate restTemplate;
 
   @Autowired
   public ConsumerController(RestTemplate restTemplate) {

--- a/integration-tests/cse-v1/consumer/src/main/java/com/huaweicloud/samples/ConsumerGovernanceController.java
+++ b/integration-tests/cse-v1/consumer/src/main/java/com/huaweicloud/samples/ConsumerGovernanceController.java
@@ -31,7 +31,7 @@ import org.springframework.web.client.RestTemplate;
 @RestController
 @RequestMapping(path = "govern")
 public class ConsumerGovernanceController {
-  private Map<String, Integer> retryTimes = new HashMap<>();
+  private final Map<String, Integer> retryTimes = new HashMap<>();
 
   private int count = 0;
 

--- a/integration-tests/cse-v1/tests-client/src/test/java/com/huaweicloud/sample/ConsumerConfigIT.java
+++ b/integration-tests/cse-v1/tests-client/src/test/java/com/huaweicloud/sample/ConsumerConfigIT.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestTemplate;
 
 public class ConsumerConfigIT {
-  RestTemplate template = new RestTemplate();
+  final RestTemplate template = new RestTemplate();
 
   @Test
   public void testConfig() {

--- a/integration-tests/cse-v1/tests-client/src/test/java/com/huaweicloud/sample/GatewayGovernanceIT.java
+++ b/integration-tests/cse-v1/tests-client/src/test/java/com/huaweicloud/sample/GatewayGovernanceIT.java
@@ -31,7 +31,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 public class GatewayGovernanceIT {
-  RestTemplate template = new RestTemplate();
+  final RestTemplate template = new RestTemplate();
 
   @Test
   public void testRateLimiting() throws Exception {

--- a/integration-tests/cse-v1/tests-client/src/test/java/com/huaweicloud/sample/HelloWorldIT.java
+++ b/integration-tests/cse-v1/tests-client/src/test/java/com/huaweicloud/sample/HelloWorldIT.java
@@ -28,7 +28,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 public class HelloWorldIT {
-  RestTemplate template = new RestTemplate();
+  final RestTemplate template = new RestTemplate();
 
   @Test
   public void testHelloWorld() {

--- a/integration-tests/cse-v2/consumer/src/main/java/com/huaweicloud/samples/ConsumerConfigController.java
+++ b/integration-tests/cse-v2/consumer/src/main/java/com/huaweicloud/samples/ConsumerConfigController.java
@@ -26,9 +26,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ConsumerConfigController {
 
-  private Environment environment;
+  private final Environment environment;
 
-  private ConsumerConfigurationProperties consumerConfigurationProperties;
+  private final ConsumerConfigurationProperties consumerConfigurationProperties;
 
   @Autowired
   public ConsumerConfigController(Environment environment, ConsumerConfigurationProperties consumerConfigurationProperties) {

--- a/integration-tests/cse-v2/consumer/src/main/java/com/huaweicloud/samples/ConsumerController.java
+++ b/integration-tests/cse-v2/consumer/src/main/java/com/huaweicloud/samples/ConsumerController.java
@@ -26,7 +26,7 @@ import org.springframework.web.client.RestTemplate;
 @RestController
 public class ConsumerController {
 
-  private RestTemplate restTemplate;
+  private final RestTemplate restTemplate;
 
   @Autowired
   public ConsumerController(RestTemplate restTemplate) {

--- a/integration-tests/cse-v2/tests-client/src/test/java/com/huaweicloud/sample/ConsumerConfigIT.java
+++ b/integration-tests/cse-v2/tests-client/src/test/java/com/huaweicloud/sample/ConsumerConfigIT.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestTemplate;
 
 public class ConsumerConfigIT {
-  RestTemplate template = new RestTemplate();
+  final RestTemplate template = new RestTemplate();
 
   @Test
   public void testConfig() {

--- a/integration-tests/cse-v2/tests-client/src/test/java/com/huaweicloud/sample/HelloWorldIT.java
+++ b/integration-tests/cse-v2/tests-client/src/test/java/com/huaweicloud/sample/HelloWorldIT.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestTemplate;
 
 public class HelloWorldIT {
-  RestTemplate template = new RestTemplate();
+  final RestTemplate template = new RestTemplate();
 
   @Test
   public void testHelloWorld() {

--- a/integration-tests/discovery-tests/discovery-tests-client/src/test/java/com/huaweicloud/sample/CrossAppControllerIT.java
+++ b/integration-tests/discovery-tests/discovery-tests-client/src/test/java/com/huaweicloud/sample/CrossAppControllerIT.java
@@ -26,11 +26,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestTemplate;
 
 public class CrossAppControllerIT {
-  String url = "http://127.0.0.1:9098";
+  final String url = "http://127.0.0.1:9098";
 
-  int crossAppPricePort = 9092;
+  final int crossAppPricePort = 9092;
 
-  RestTemplate template = new RestTemplate();
+  final RestTemplate template = new RestTemplate();
 
   @Test
   public void testGetOrder() {

--- a/integration-tests/discovery-tests/discovery-tests-client/src/test/java/com/huaweicloud/sample/GovernanceControllerIT.java
+++ b/integration-tests/discovery-tests/discovery-tests-client/src/test/java/com/huaweicloud/sample/GovernanceControllerIT.java
@@ -29,9 +29,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestTemplate;
 
 public class GovernanceControllerIT {
-  String url = "http://127.0.0.1:9098";
+  final String url = "http://127.0.0.1:9098";
 
-  RestTemplate template = new RestTemplate();
+  final RestTemplate template = new RestTemplate();
 
   @Test
   public void testRetry() {

--- a/integration-tests/discovery-tests/discovery-tests-client/src/test/java/com/huaweicloud/sample/HessianControllerIT.java
+++ b/integration-tests/discovery-tests/discovery-tests-client/src/test/java/com/huaweicloud/sample/HessianControllerIT.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestTemplate;
 
 public class HessianControllerIT {
-  String url = "http://127.0.0.1:9098";
+  final String url = "http://127.0.0.1:9098";
 
-  RestTemplate template = new RestTemplate();
+  final RestTemplate template = new RestTemplate();
 
   @Test
   public void testHessian() {

--- a/integration-tests/discovery-tests/discovery-tests-client/src/test/java/com/huaweicloud/sample/OrderControllerIT.java
+++ b/integration-tests/discovery-tests/discovery-tests-client/src/test/java/com/huaweicloud/sample/OrderControllerIT.java
@@ -27,11 +27,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestTemplate;
 
 public class OrderControllerIT {
-  String url = "http://127.0.0.1:9098";
+  final String url = "http://127.0.0.1:9098";
 
-  int pricePort = 9090;
+  final int pricePort = 9090;
 
-  RestTemplate template = new RestTemplate();
+  final RestTemplate template = new RestTemplate();
 
   @Test
   public void testGetOrder() {

--- a/integration-tests/discovery-tests/discovery-tests-client/src/test/java/com/huaweicloud/sample/ProductControllerIT.java
+++ b/integration-tests/discovery-tests/discovery-tests-client/src/test/java/com/huaweicloud/sample/ProductControllerIT.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestTemplate;
 
 public class ProductControllerIT {
-  String url = "http://127.0.0.1:9098";
+  final String url = "http://127.0.0.1:9098";
 
-  RestTemplate template = new RestTemplate();
+  final RestTemplate template = new RestTemplate();
 
   @Test
   public void testGetProduct() {

--- a/integration-tests/discovery-tests/discovery-tests-client/src/test/java/com/huaweicloud/sample/SchemaControllerIT.java
+++ b/integration-tests/discovery-tests/discovery-tests-client/src/test/java/com/huaweicloud/sample/SchemaControllerIT.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestTemplate;
 
 public class SchemaControllerIT {
-  String url = "http://127.0.0.1:9098";
+  final String url = "http://127.0.0.1:9098";
 
-  RestTemplate template = new RestTemplate();
+  final RestTemplate template = new RestTemplate();
 
   @Test
   public void testSchemaGeneratorSpringCloud() {

--- a/integration-tests/discovery-tests/order-consumer/src/main/java/com/huaweicloud/sample/GovernanceController.java
+++ b/integration-tests/discovery-tests/order-consumer/src/main/java/com/huaweicloud/sample/GovernanceController.java
@@ -27,9 +27,9 @@ import org.springframework.web.client.RestTemplate;
 @RequestMapping(path = "govern")
 public class GovernanceController {
 
-  private RestTemplate restTemplate;
+  private final RestTemplate restTemplate;
 
-  private FeignService feignService;
+  private final FeignService feignService;
 
   private int count = 0;
 

--- a/integration-tests/discovery-tests/order-consumer/src/main/java/com/huaweicloud/sample/OrderController.java
+++ b/integration-tests/discovery-tests/order-consumer/src/main/java/com/huaweicloud/sample/OrderController.java
@@ -27,9 +27,9 @@ import org.springframework.web.client.RestTemplate;
 @RestController
 public class OrderController {
 
-  private DiscoveryClient discoveryClient;
+  private final DiscoveryClient discoveryClient;
 
-  private RestTemplate restTemplate;
+  private final RestTemplate restTemplate;
 
   @Autowired
   public OrderController(DiscoveryClient discoveryClient, RestTemplate restTemplate) {

--- a/integration-tests/discovery-tests/order-consumer/src/main/java/com/huaweicloud/sample/SchemaController.java
+++ b/integration-tests/discovery-tests/order-consumer/src/main/java/com/huaweicloud/sample/SchemaController.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -43,9 +44,9 @@ import io.swagger.util.Yaml;
 @RestController
 public class SchemaController {
 
-  ServiceCombSwaggerHandler serviceCombSwaggerHandler;
+  final ServiceCombSwaggerHandler serviceCombSwaggerHandler;
 
-  private RestTemplate restTemplate;
+  private final RestTemplate restTemplate;
 
   @Autowired
   public SchemaController(ServiceCombSwaggerHandler serviceCombSwaggerHandler, RestTemplate restTemplate) {
@@ -85,7 +86,7 @@ public class SchemaController {
       int len = inputStream.read(buffer);
       assertThat(len).isLessThan(2048 * 10);
       inputStream.close();
-      return new String(buffer, 0, len, Charset.forName("UTF-8"));
+      return new String(buffer, 0, len, StandardCharsets.UTF_8);
     } catch (IOException e) {
       Assertions.fail(e.getMessage());
       return null;

--- a/integration-tests/discovery-tests/price-provider/src/main/java/com/huaweicloud/sample/GovernanceController.java
+++ b/integration-tests/discovery-tests/price-provider/src/main/java/com/huaweicloud/sample/GovernanceController.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class GovernanceController {
-  private Map<String, Integer> retryTimes = new HashMap<>();
+  private final Map<String, Integer> retryTimes = new HashMap<>();
 
   @RequestMapping("/hello")
   public String sayHello() {

--- a/integration-tests/discovery-tests/price-provider/src/main/java/com/huaweicloud/sample/SchemaController.java
+++ b/integration-tests/discovery-tests/price-provider/src/main/java/com/huaweicloud/sample/SchemaController.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -69,7 +70,7 @@ public class SchemaController {
       int len = inputStream.read(buffer);
       assertThat(len).isLessThan(2048 * 10);
       inputStream.close();
-      return new String(buffer, 0, len, Charset.forName("UTF-8"));
+      return new String(buffer, 0, len, StandardCharsets.UTF_8);
     } catch (IOException e) {
       Assertions.fail(e.getMessage());
       return null;

--- a/spring-cloud-huawei-common/src/main/java/com/huaweicloud/common/event/EventManager.java
+++ b/spring-cloud-huawei-common/src/main/java/com/huaweicloud/common/event/EventManager.java
@@ -20,7 +20,7 @@ package com.huaweicloud.common.event;
 import com.google.common.eventbus.EventBus;
 
 public class EventManager {
-  private static EventBus eventBus = new EventBus();
+  private static final EventBus eventBus = new EventBus();
 
   public static EventBus getEventBus() {
     return eventBus;

--- a/spring-cloud-huawei-common/src/main/java/com/huaweicloud/common/transport/AkSkRequestAuthHeaderProvider.java
+++ b/spring-cloud-huawei-common/src/main/java/com/huaweicloud/common/transport/AkSkRequestAuthHeaderProvider.java
@@ -32,7 +32,7 @@ public class AkSkRequestAuthHeaderProvider implements AuthHeaderProvider {
 
   public static final String X_SERVICE_PROJECT = "X-Service-Project";
 
-  private ServiceCombAkSkProperties serviceCombAkSkProperties;
+  private final ServiceCombAkSkProperties serviceCombAkSkProperties;
 
   public AkSkRequestAuthHeaderProvider(ServiceCombAkSkProperties serviceCombAkSkProperties) {
     this.serviceCombAkSkProperties = serviceCombAkSkProperties;

--- a/spring-cloud-huawei-config/src/main/java/com/huaweicloud/config/ConfigService.java
+++ b/spring-cloud-huawei-config/src/main/java/com/huaweicloud/config/ConfigService.java
@@ -174,7 +174,7 @@ public class ConfigService {
       addresses = URLUtil.dealMultiUrl(configProperties.getServerAddr());
     }
     LOGGER
-        .info("initialize config server type={}, address={}.", configProperties.getServerType(), addresses.toString());
+        .info("initialize config server type={}, address={}.", configProperties.getServerType(), addresses);
     return createKieAddressManager(addresses);
   }
 

--- a/spring-cloud-huawei-config/src/main/java/com/huaweicloud/config/ServiceCombPropertySourceLocator.java
+++ b/spring-cloud-huawei-config/src/main/java/com/huaweicloud/config/ServiceCombPropertySourceLocator.java
@@ -26,7 +26,7 @@ import org.springframework.core.env.PropertySource;
 
 @Order(0)
 public class ServiceCombPropertySourceLocator implements PropertySourceLocator {
-  private ConfigConverter configConverter;
+  private final ConfigConverter configConverter;
 
   public ServiceCombPropertySourceLocator(ConfigConverter configConverter) {
     this.configConverter = configConverter;

--- a/spring-cloud-huawei-config/src/test/java/com/huaweicloud/config/client/ServiceCombConfigPropertySourceTest.java
+++ b/spring-cloud-huawei-config/src/test/java/com/huaweicloud/config/client/ServiceCombConfigPropertySourceTest.java
@@ -30,7 +30,7 @@ import mockit.MockUp;
 
 public class ServiceCombConfigPropertySourceTest extends MockUp<ServiceCombConfigPropertySource> {
 
-  private Map<String, Object> properties = new HashMap<>();
+  private final Map<String, Object> properties = new HashMap<>();
 
   @Test
   public void getPropertyNames() {

--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/ServiceAddressManager.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/ServiceAddressManager.java
@@ -47,15 +47,15 @@ public class ServiceAddressManager {
 
   private boolean initialized = false;
 
-  private ServiceCenterClient serviceCenterClient;
+  private final ServiceCenterClient serviceCenterClient;
 
-  private MicroserviceInstance myselfInstance;
+  private final MicroserviceInstance myselfInstance;
 
-  private DiscoveryBootstrapProperties discoveryProperties;
+  private final DiscoveryBootstrapProperties discoveryProperties;
 
   private DataCenterInfo dataCenterInfo;
 
-  private String myselfServiceId;
+  private final String myselfServiceId;
 
   public ServiceAddressManager(DiscoveryBootstrapProperties discoveryProperties,
       ServiceCenterClient serviceCenterClient,

--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/ServiceCombDiscoveryClient.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/ServiceCombDiscoveryClient.java
@@ -52,13 +52,13 @@ import com.huaweicloud.servicecomb.discovery.registry.ServiceCombRegistration;
 public class ServiceCombDiscoveryClient implements DiscoveryClient, ApplicationEventPublisherAware {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServiceCombDiscoveryClient.class);
 
-  private ServiceCenterClient serviceCenterClient;
+  private final ServiceCenterClient serviceCenterClient;
 
-  private DiscoveryBootstrapProperties discoveryProperties;
+  private final DiscoveryBootstrapProperties discoveryProperties;
 
-  private ServiceCenterDiscovery serviceCenterDiscovery;
+  private final ServiceCenterDiscovery serviceCenterDiscovery;
 
-  private ServiceCombRegistration serviceCombRegistration;
+  private final ServiceCombRegistration serviceCombRegistration;
 
   private ApplicationEventPublisher applicationEventPublisher;
 

--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/ServiceCombReactiveDiscoveryClient.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/discovery/ServiceCombReactiveDiscoveryClient.java
@@ -25,7 +25,7 @@ import reactor.core.scheduler.Schedulers;
 
 public class ServiceCombReactiveDiscoveryClient implements ReactiveDiscoveryClient {
 
-  private DiscoveryClient discoveryClient;
+  private final DiscoveryClient discoveryClient;
 
   public ServiceCombReactiveDiscoveryClient(DiscoveryClient discoveryClient) {
     this.discoveryClient = discoveryClient;

--- a/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/registry/ServiceCombRegistration.java
+++ b/spring-cloud-huawei-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/registry/ServiceCombRegistration.java
@@ -36,11 +36,11 @@ import com.huaweicloud.common.transport.DiscoveryBootstrapProperties;
  */
 public class ServiceCombRegistration implements Registration {
 
-  private Microservice microservice;
+  private final Microservice microservice;
 
-  private MicroserviceInstance microserviceInstance;
+  private final MicroserviceInstance microserviceInstance;
 
-  private DiscoveryBootstrapProperties discoveryBootstrapProperties;
+  private final DiscoveryBootstrapProperties discoveryBootstrapProperties;
 
   public ServiceCombRegistration(DiscoveryBootstrapProperties discoveryBootstrapProperties,
       DiscoveryProperties discoveryProperties,

--- a/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/GovernanceClientHttpRequestInterceptor.java
+++ b/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/GovernanceClientHttpRequestInterceptor.java
@@ -35,7 +35,7 @@ import io.vavr.CheckedFunction0;
 
 public class GovernanceClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
 
-  private RetryHandler retryHandler;
+  private final RetryHandler retryHandler;
 
   private ClientRecoverPolicy<Object> clientRecoverPolicy;
 

--- a/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/GovernanceFeignClient.java
+++ b/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/GovernanceFeignClient.java
@@ -41,7 +41,7 @@ import feign.Response;
 @Aspect
 public class GovernanceFeignClient {
 
-  private RetryHandler retryHandler;
+  private final RetryHandler retryHandler;
 
   private ClientRecoverPolicy<Object> clientRecoverPolicy;
 

--- a/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/GovernanceRequestMappingHandlerAdapter.java
+++ b/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/GovernanceRequestMappingHandlerAdapter.java
@@ -52,11 +52,11 @@ public class GovernanceRequestMappingHandlerAdapter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GovernanceRequestMappingHandlerAdapter.class);
 
-  private RateLimitingHandler rateLimitingHandler;
+  private final RateLimitingHandler rateLimitingHandler;
 
-  private CircuitBreakerHandler circuitBreakerHandler;
+  private final CircuitBreakerHandler circuitBreakerHandler;
 
-  private BulkheadHandler bulkheadHandler;
+  private final BulkheadHandler bulkheadHandler;
 
   private ServerRecoverPolicy<Object> serverRecoverPolicy;
 

--- a/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/SpringCloudInvocationContext.java
+++ b/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/SpringCloudInvocationContext.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.apache.servicecomb.governance.InvocationContext;
 
 public class SpringCloudInvocationContext implements InvocationContext {
-  private static ThreadLocal<Map<String, Boolean>> context = new ThreadLocal<>();
+  private static final ThreadLocal<Map<String, Boolean>> context = new ThreadLocal<>();
 
   public static void setInvocationContext() {
     context.set(new HashMap<>());

--- a/spring-cloud-huawei-governance/src/test/java/com/huaweicloud/governance/TestOperator.java
+++ b/spring-cloud-huawei-governance/src/test/java/com/huaweicloud/governance/TestOperator.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 
 public class TestOperator {
 
-  private Map<String, MatchOperator> operatorMap;
+  private final Map<String, MatchOperator> operatorMap;
 
   private static final String PREFIX_KEY = "prefix";
 

--- a/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/loabalancer/CanaryServiceInstanceFilter.java
+++ b/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/loabalancer/CanaryServiceInstanceFilter.java
@@ -42,9 +42,9 @@ public class CanaryServiceInstanceFilter implements ServiceInstanceFilter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CanaryServiceInstanceFilter.class);
 
-  private AbstractRouterDistributor<ServiceInstance, MicroserviceInstance> routerDistributor;
+  private final AbstractRouterDistributor<ServiceInstance, MicroserviceInstance> routerDistributor;
 
-  private RouterFilter routerFilter;
+  private final RouterFilter routerFilter;
 
   @Autowired
   public CanaryServiceInstanceFilter(AbstractRouterDistributor<ServiceInstance, MicroserviceInstance> routerDistributor, RouterFilter routerFilter) {

--- a/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/loabalancer/RouterLoadBalancerRequest.java
+++ b/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/loabalancer/RouterLoadBalancerRequest.java
@@ -23,7 +23,7 @@ import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 
 public class RouterLoadBalancerRequest implements LoadBalancerRequest<ClientHttpResponse> {
-  private LoadBalancerRequest<ClientHttpResponse> delegate;
+  private final LoadBalancerRequest<ClientHttpResponse> delegate;
 
   private HttpRequest request;
 

--- a/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/loabalancer/RouterServiceInstanceListSupplier.java
+++ b/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/loabalancer/RouterServiceInstanceListSupplier.java
@@ -36,7 +36,7 @@ public class RouterServiceInstanceListSupplier implements ServiceInstanceListSup
 
   private List<ServiceInstanceFilter> filters;
 
-  private ServiceInstanceListSupplier delegate;
+  private final ServiceInstanceListSupplier delegate;
 
   public RouterServiceInstanceListSupplier(ServiceInstanceListSupplier delegate) {
     this.delegate = delegate;

--- a/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/track/RouterTrackContext.java
+++ b/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/track/RouterTrackContext.java
@@ -22,7 +22,7 @@ package com.huaweicloud.router.client.track;
 public class RouterTrackContext {
   public static final String ROUTER_TRACK_HEADER = "X-RouterContext";
 
-  private static ThreadLocal<String> requestHeaderThreadLocal = new ThreadLocal<>();
+  private static final ThreadLocal<String> requestHeaderThreadLocal = new ThreadLocal<>();
 
   public static void remove() {
     requestHeaderThreadLocal.remove();

--- a/spring-cloud-huawei-swagger/src/main/java/com/huaweicloud/swagger/DefinitionCache.java
+++ b/spring-cloud-huawei-swagger/src/main/java/com/huaweicloud/swagger/DefinitionCache.java
@@ -25,9 +25,9 @@ import java.util.Map;
  **/
 public class DefinitionCache {
 
-  private static Map<String, String> definitionMap = new HashMap<>();
+  private static final Map<String, String> definitionMap = new HashMap<>();
 
-  private static Map<String, String> schemaClassNameMap = new HashMap<>();
+  private static final Map<String, String> schemaClassNameMap = new HashMap<>();
 
   public static String getClassByDefName(String name) {
     return definitionMap.get(name);

--- a/spring-cloud-huawei-swagger/src/main/java/com/huaweicloud/swagger/ServiceCombSwaggerHandlerImpl.java
+++ b/spring-cloud-huawei-swagger/src/main/java/com/huaweicloud/swagger/ServiceCombSwaggerHandlerImpl.java
@@ -45,11 +45,11 @@ public class ServiceCombSwaggerHandlerImpl implements ServiceCombSwaggerHandler 
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ServiceCombSwaggerHandlerImpl.class);
 
-  protected DocumentationPluginsBootstrapper documentationPluginsBootstrapper;
+  protected final DocumentationPluginsBootstrapper documentationPluginsBootstrapper;
 
-  protected DocumentationCache documentationCache;
+  protected final DocumentationCache documentationCache;
 
-  protected ServiceModelToSwagger2Mapper mapper;
+  protected final ServiceModelToSwagger2Mapper mapper;
 
   @Autowired
   public ServiceCombSwaggerHandlerImpl(DocumentationPluginsBootstrapper documentationPluginsBootstrapper, DocumentationCache documentationCache, ServiceModelToSwagger2Mapper mapper) {

--- a/spring-cloud-huawei-swagger/src/main/java/com/huaweicloud/swagger/SpringCloudDocumentationSwaggerMapper.java
+++ b/spring-cloud-huawei-swagger/src/main/java/com/huaweicloud/swagger/SpringCloudDocumentationSwaggerMapper.java
@@ -29,7 +29,7 @@ import springfox.documentation.service.Documentation;
 import springfox.documentation.swagger2.mappers.ServiceModelToSwagger2Mapper;
 
 public class SpringCloudDocumentationSwaggerMapper implements DocumentationSwaggerMapper {
-  private ServiceModelToSwagger2Mapper mapper;
+  private final ServiceModelToSwagger2Mapper mapper;
 
   public SpringCloudDocumentationSwaggerMapper(ServiceModelToSwagger2Mapper mapper) {
     this.mapper = mapper;

--- a/spring-cloud-starter-huawei/spring-cloud-starter-huawei-service-engine-gateway/src/main/java/com/huaweicloud/gateway/governance/GovernanceGatewayFilterFactory.java
+++ b/spring-cloud-starter-huawei/spring-cloud-starter-huawei-service-engine-gateway/src/main/java/com/huaweicloud/gateway/governance/GovernanceGatewayFilterFactory.java
@@ -56,13 +56,13 @@ public class GovernanceGatewayFilterFactory
     extends AbstractGatewayFilterFactory<GovernanceGatewayFilterFactory.Config> {
   private static final Logger LOGGER = LoggerFactory.getLogger(GovernanceGatewayFilterFactory.class);
 
-  private RateLimitingHandler rateLimitingHandler;
+  private final RateLimitingHandler rateLimitingHandler;
 
-  private CircuitBreakerHandler circuitBreakerHandler;
+  private final CircuitBreakerHandler circuitBreakerHandler;
 
-  private BulkheadHandler bulkheadHandler;
+  private final BulkheadHandler bulkheadHandler;
 
-  private RetryHandler retryHandler;
+  private final RetryHandler retryHandler;
 
   @Autowired
   public GovernanceGatewayFilterFactory(RateLimitingHandler rateLimitingHandler, CircuitBreakerHandler circuitBreakerHandler, BulkheadHandler bulkheadHandler, RetryHandler retryHandler) {


### PR DESCRIPTION
Marking fields as `final` is always good for reader and compiler
1. the reader knows these fields value will never change.
2. The compiler can do more optimize based on final keyword.