### PR TITLE
[#669]Fixes the problem that gray rules cannot match instances when cross-application invoking.

### DIFF
--- a/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/loabalancer/CanaryServiceInstanceFilter.java
+++ b/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/loabalancer/CanaryServiceInstanceFilter.java
@@ -32,6 +32,7 @@ import org.springframework.cloud.client.loadbalancer.Request;
 import org.springframework.cloud.client.loadbalancer.RequestData;
 import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
 import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -56,7 +57,7 @@ public class CanaryServiceInstanceFilter implements ServiceInstanceFilter {
   @SuppressWarnings({"rawtypes", "unchecked"})
   public List<ServiceInstance> filter(ServiceInstanceListSupplier supplier, List<ServiceInstance> instances,
       Request<?> request) {
-    String targetServiceName = supplier.getServiceId();
+    String targetServiceName = StringUtils.unqualify(supplier.getServiceId());
     DefaultRequestContext context = (DefaultRequestContext) request.getContext();
 
     Object clientRequest = context.getClientRequest();


### PR DESCRIPTION
During cross-application invoking, targetServiceName changes to application name + microservice name.Fix the problem by fixing targetServiceName to the microservice name.