### PR TITLE
[#669]Fixes the problem that gray rules cannot match instances when cross-application invoking

### DIFF
--- a/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/loabalancer/CanaryServiceInstanceFilter.java
+++ b/spring-cloud-huawei-router-client/src/main/java/com/huaweicloud/router/client/loabalancer/CanaryServiceInstanceFilter.java
@@ -19,6 +19,7 @@ package com.huaweicloud.router.client.loabalancer;
 
 import com.huaweicloud.router.client.track.RouterTrackContext;
 
+import com.huaweicloud.servicecomb.discovery.client.model.ServiceCombServiceInstance;
 import org.apache.servicecomb.foundation.common.utils.JsonUtils;
 import org.apache.servicecomb.router.RouterFilter;
 import org.apache.servicecomb.router.distribute.AbstractRouterDistributor;
@@ -56,9 +57,8 @@ public class CanaryServiceInstanceFilter implements ServiceInstanceFilter {
   @SuppressWarnings({"rawtypes", "unchecked"})
   public List<ServiceInstance> filter(ServiceInstanceListSupplier supplier, List<ServiceInstance> instances,
       Request<?> request) {
-    String targetServiceName = supplier.getServiceId();
+    String  targetServiceName = ((ServiceCombServiceInstance) instances.get(0)).getServiceId();
     DefaultRequestContext context = (DefaultRequestContext) request.getContext();
-
     Object clientRequest = context.getClientRequest();
     HttpHeaders httpHeaders;
     if (clientRequest instanceof RouterLoadBalancerRequest) {
@@ -79,7 +79,6 @@ public class CanaryServiceInstanceFilter implements ServiceInstanceFilter {
     } catch (IOException e) {
       LOGGER.warn("decode headers failed for {}", e.getMessage());
     }
-
     return routerFilter
         .getFilteredListOfServers(instances, targetServiceName, canaryHeaders,
             routerDistributor);


### PR DESCRIPTION

During cross-application invoking, targetServiceName changes to application name + microservice name.Fix the problem by fixing targetServiceName to the microservice name.