### PR TITLE
[#1099] adjusting new logic and configuration for security

### DIFF
--- a/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/Const.java
+++ b/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/Const.java
@@ -25,4 +25,6 @@ public class Const {
   public static final String AUTH_SERVICE_NAME = "serviceName";
 
   public static final String AUTH_TOKEN_CHECK_ENABLED = "spring.cloud.servicecomb.webmvc.publicKey.tokenCheckEnabled";
+
+  public static final String AUTH_TOKEN_HEADER_KEY = "spring.cloud.servicecomb.webmvc.publicKey.headerTokenKey";
 }

--- a/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/RSAProviderTokenManager.java
+++ b/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/RSAProviderTokenManager.java
@@ -56,7 +56,10 @@ public class RSAProviderTokenManager {
       AuthRequestExtractor extractor;
       if (environment.getProperty(Const.AUTH_TOKEN_CHECK_ENABLED, boolean.class, true)
           || StringUtils.isEmpty(request.getHeader(Const.AUTH_SERVICE_NAME))) {
-        RsaAuthenticationToken rsaToken = RSATokenCheckUtils.checkTokenInfo(request, authenticationAdapter);
+        String headerTokenKey = environment.getProperty(Const.AUTH_TOKEN_HEADER_KEY, String.class,
+            "X-SM-Token");
+        RsaAuthenticationToken rsaToken = RSATokenCheckUtils.checkTokenInfo(request, authenticationAdapter,
+            headerTokenKey);
         extractor = AuthRequestExtractorUtils.createAuthRequestExtractor(request, rsaToken.getServiceId(),
             rsaToken.getInstanceId());
       } else {

--- a/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/RSATokenCheckUtils.java
+++ b/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/RSATokenCheckUtils.java
@@ -38,8 +38,8 @@ public class RSATokenCheckUtils {
       .build();
 
   public static RsaAuthenticationToken checkTokenInfo(HttpServletRequest request,
-      AuthenticationAdapter authenticationAdapter) throws Exception {
-    String token = request.getHeader(Const.AUTH_TOKEN);
+      AuthenticationAdapter authenticationAdapter, String headerTokenKey) throws Exception {
+    String token = request.getHeader(headerTokenKey);
     if (StringUtils.isEmpty(token)) {
       token = InvocationContextHolder.getOrCreateInvocationContext().getContext(Const.AUTH_TOKEN);
     }

--- a/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyAccessController.java
+++ b/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyAccessController.java
@@ -43,7 +43,7 @@ public class SecurityPolicyAccessController implements AccessController {
   public boolean isAllowed(AuthRequestExtractor extractor) throws Exception {
     String currentServiceName = extractor.serviceName();
     if (StringUtils.isEmpty(extractor.serviceId()) && StringUtils.isEmpty(currentServiceName)) {
-      LOGGER.info("consumer has no serviceName info in header, please set it for authentication");
+      LOGGER.warn("consumer has no serviceName info in header, please set it for authentication");
       throw new UnAuthorizedException("UNAUTHORIZED.");
     }
     if (StringUtils.isEmpty(currentServiceName)) {
@@ -55,9 +55,9 @@ public class SecurityPolicyAccessController implements AccessController {
   private boolean checkDeny(String serviceName, AuthRequestExtractor extractor) {
     if (securityPolicyProperties.matchDeny(serviceName, extractor.uri(), extractor.method())) {
       // both permissive and enforcing model need print logs(send alarm info).
-      LOGGER.info("[autoauthz unauthorized request] consumer={}, provider={}, path={}, method={}, timestamp={}",
-          serviceName, securityPolicyProperties.getProvider(), extractor.uri(), extractor.method(),
-          System.currentTimeMillis());
+      LOGGER.warn("[autoauthz suspicious request] mode={}, consumer={}, provider={}, path={}, method={}, timestamp={}",
+          securityPolicyProperties.getMode(), serviceName, securityPolicyProperties.getProvider(), extractor.uri(),
+          extractor.method(), System.currentTimeMillis());
       // permissive mode, black policy match allow passing
       return !"permissive".equals(securityPolicyProperties.getMode());
     } else {
@@ -70,9 +70,9 @@ public class SecurityPolicyAccessController implements AccessController {
       return !checkDeny(serviceName, extractor);
     } else {
       // both permissive and enforcing model need print logs(send alarm info).
-      LOGGER.info("[autoauthz unauthorized request] consumer={}, provider={}, path={}, method={}, timestamp={}",
-          serviceName, securityPolicyProperties.getProvider(), extractor.uri(), extractor.method(),
-          System.currentTimeMillis());
+      LOGGER.warn("[autoauthz suspicious request] mode={}, consumer={}, provider={}, path={}, method={}, timestamp={}",
+          securityPolicyProperties.getMode(), serviceName, securityPolicyProperties.getProvider(), extractor.uri(),
+          extractor.method(), System.currentTimeMillis());
       // permissive mode, white policy not match allow passing
       return "permissive".equals(securityPolicyProperties.getMode());
     }

--- a/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyAccessController.java
+++ b/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyAccessController.java
@@ -55,9 +55,9 @@ public class SecurityPolicyAccessController implements AccessController {
   private boolean checkDeny(String serviceName, AuthRequestExtractor extractor) {
     if (securityPolicyProperties.matchDeny(serviceName, extractor.uri(), extractor.method())) {
       // both permissive and enforcing model need print logs(send alarm info).
-      LOGGER.warn("[autoauthz suspicious request] mode={}, consumer={}, provider={}, path={}, method={}, timestamp={}",
-          securityPolicyProperties.getMode(), serviceName, securityPolicyProperties.getProvider(), extractor.uri(),
-          extractor.method(), System.currentTimeMillis());
+      LOGGER.warn("[autoauthz unauthorized request] mode={}, consumer={}, provider={}, path={}, method={},"
+          + "timestamp={}", securityPolicyProperties.getMode(), serviceName, securityPolicyProperties.getProvider(),
+          extractor.uri(), extractor.method(), System.currentTimeMillis());
       // permissive mode, black policy match allow passing
       return !"permissive".equals(securityPolicyProperties.getMode());
     } else {
@@ -70,9 +70,9 @@ public class SecurityPolicyAccessController implements AccessController {
       return !checkDeny(serviceName, extractor);
     } else {
       // both permissive and enforcing model need print logs(send alarm info).
-      LOGGER.warn("[autoauthz suspicious request] mode={}, consumer={}, provider={}, path={}, method={}, timestamp={}",
-          securityPolicyProperties.getMode(), serviceName, securityPolicyProperties.getProvider(), extractor.uri(),
-          extractor.method(), System.currentTimeMillis());
+      LOGGER.warn("[autoauthz unauthorized request] mode={}, consumer={}, provider={}, path={}, method={},"
+          + "timestamp={}", securityPolicyProperties.getMode(), serviceName, securityPolicyProperties.getProvider(),
+          extractor.uri(), extractor.method(), System.currentTimeMillis());
       // permissive mode, white policy not match allow passing
       return "permissive".equals(securityPolicyProperties.getMode());
     }

--- a/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyAccessController.java
+++ b/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyAccessController.java
@@ -54,15 +54,12 @@ public class SecurityPolicyAccessController implements AccessController {
 
   private boolean checkDeny(String serviceName, AuthRequestExtractor extractor) {
     if (securityPolicyProperties.matchDeny(serviceName, extractor.uri(), extractor.method())) {
+      // both permissive and enforcing model need print logs(send alarm info).
+      LOGGER.info("[autoauthz unauthorized request] consumer={}, provider={}, path={}, method={}, timestamp={}",
+          serviceName, securityPolicyProperties.getProvider(), extractor.uri(), extractor.method(),
+          System.currentTimeMillis());
       // permissive mode, black policy match allow passing
-      if ("permissive".equals(securityPolicyProperties.getMode())) {
-        LOGGER.info("[autoauthz unauthorized request] consumer={}, provider={}, path={}, method={}, timestamp={}",
-            serviceName, securityPolicyProperties.getProvider(), extractor.uri(), extractor.method(),
-            System.currentTimeMillis());
-        return false;
-      } else {
-        return true;
-      }
+      return !"permissive".equals(securityPolicyProperties.getMode());
     } else {
       return false;
     }
@@ -72,15 +69,12 @@ public class SecurityPolicyAccessController implements AccessController {
     if (securityPolicyProperties.matchAllow(serviceName, extractor.uri(), extractor.method())) {
       return !checkDeny(serviceName, extractor);
     } else {
+      // both permissive and enforcing model need print logs(send alarm info).
+      LOGGER.info("[autoauthz unauthorized request] consumer={}, provider={}, path={}, method={}, timestamp={}",
+          serviceName, securityPolicyProperties.getProvider(), extractor.uri(), extractor.method(),
+          System.currentTimeMillis());
       // permissive mode, white policy not match allow passing
-      if ("permissive".equals(securityPolicyProperties.getMode())) {
-        LOGGER.info("[autoauthz unauthorized request] consumer={}, provider={}, path={}, method={}, timestamp={}",
-            serviceName, securityPolicyProperties.getProvider(), extractor.uri(), extractor.method(),
-            System.currentTimeMillis());
-        return true;
-      } else {
-        return false;
-      }
+      return "permissive".equals(securityPolicyProperties.getMode());
     }
   }
 

--- a/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyProperties.java
+++ b/spring-cloud-huawei-governance/src/main/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyProperties.java
@@ -137,8 +137,9 @@ public class SecurityPolicyProperties {
   }
 
   public boolean matchAllow(String serviceName, String uri, String method) {
+    // If have no allow policy, intercept requests.
     if (action == null || action.allow.isEmpty()) {
-      return true;
+      return false;
     }
 
     for (ConfigurationItem item : action.allow) {

--- a/spring-cloud-huawei-governance/src/test/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyAccessControllerTest.java
+++ b/spring-cloud-huawei-governance/src/test/java/com/huaweicloud/governance/authentication/securityPolicy/SecurityPolicyAccessControllerTest.java
@@ -465,8 +465,8 @@ public class SecurityPolicyAccessControllerTest {
 
   @Test
   public void testDenyEnforcingNotMatch() throws Exception {
-    AuthRequestExtractor extractor = createAuthRequestExtractor("/checkToken");
-    Assertions.assertTrue(getDenyAccessController("enforcing")
+    AuthRequestExtractor extractor = createAuthRequestExtractor("/checkTokenSecurityAllow");
+    Assertions.assertTrue(getBothAccessController("enforcing")
         .isAllowed(extractor));
   }
 


### PR DESCRIPTION
1、策略uri配置/*时，客户端对应方法类型的请求都通过；
2、开启安全策略校验，但是没有设置策略或者安全策略白名单为空时，打印告警日志（发送告警信息），宽容模式请求通过，强制模式，请求拦截；
3、header中获取token的key调整为支持配置，默认为X-SM-Token。