### PR TITLE
[#1365] add router config to config-center can not be load when consumer service already started

### DIFF
--- a/spring-cloud-huawei-nacos/spring-cloud-huawei-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
+++ b/spring-cloud-huawei-nacos/spring-cloud-huawei-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
@@ -29,6 +29,7 @@ import com.huaweicloud.nacos.config.NacosConfigConst;
 import com.alibaba.cloud.nacos.NacosConfigProperties;
 import com.alibaba.cloud.nacos.NacosPropertySourceRepository;
 import com.alibaba.cloud.nacos.client.NacosPropertySource;
+import com.huaweicloud.nacos.config.client.LabelRouterConfigListener;
 import com.huaweicloud.nacos.config.manager.ConfigServiceManagerUtils;
 import com.huaweicloud.nacos.config.manager.NacosConfigManager;
 import com.alibaba.nacos.api.config.ConfigService;
@@ -195,6 +196,9 @@ public class NacosContextRefresher
           registerNacosListener(propertySource.getGroup(), propertySource.getDataId(), currentConfigServiceManager);
         }
       }
+      if (env.getProperty(NacosConfigConst.ROUTER_CONFIG_DEFAULT_LOAD_ENABLED, boolean.class, false)) {
+        new LabelRouterConfigListener(this, listenerMap.keySet()).schedulerCheckLabelRouterConfig();
+      }
     } catch (NacosException e) {
       log.error("add nacos config listener error, serverAddr=[{}]", currentConfigServiceManager.getServerAddr(), e);
     }
@@ -262,5 +266,13 @@ public class NacosContextRefresher
     taskScheduler.setBeanName("Nacos-Server-Status-Check-Scheduler");
     taskScheduler.initialize();
     return taskScheduler;
+  }
+
+  public void registerAddRouterConfigListener(String dataId, String group) {
+    try {
+      registerNacosListener(group, dataId, currentConfigServiceManager);
+    } catch (NacosException e) {
+      log.error("add nacos config listener error, serverAddr=[{}]", currentConfigServiceManager.getServerAddr(), e);
+    }
   }
 }

--- a/spring-cloud-huawei-nacos/spring-cloud-huawei-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
+++ b/spring-cloud-huawei-nacos/spring-cloud-huawei-nacos-config/src/main/java/com/alibaba/cloud/nacos/refresh/NacosContextRefresher.java
@@ -197,7 +197,7 @@ public class NacosContextRefresher
         }
       }
       if (env.getProperty(NacosConfigConst.ROUTER_CONFIG_DEFAULT_LOAD_ENABLED, boolean.class, false)) {
-        new LabelRouterConfigListener(this, listenerMap.keySet()).schedulerCheckLabelRouterConfig();
+        new LabelRouterConfigListener(this, listenerMap.keySet(), env).schedulerCheckLabelRouterConfig();
       }
     } catch (NacosException e) {
       log.error("add nacos config listener error, serverAddr=[{}]", currentConfigServiceManager.getServerAddr(), e);

--- a/spring-cloud-huawei-nacos/spring-cloud-huawei-nacos-config/src/main/java/com/huaweicloud/nacos/config/client/LabelRouterConfigListener.java
+++ b/spring-cloud-huawei-nacos/spring-cloud-huawei-nacos-config/src/main/java/com/huaweicloud/nacos/config/client/LabelRouterConfigListener.java
@@ -1,0 +1,69 @@
+/*
+
+ * Copyright (C) 2020-2024 Huawei Technologies Co., Ltd. All rights reserved.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.nacos.config.client;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.util.CollectionUtils;
+
+import com.alibaba.cloud.nacos.NacosPropertySourceRepository;
+import com.alibaba.cloud.nacos.refresh.NacosContextRefresher;
+
+public class LabelRouterConfigListener {
+  private final ThreadPoolTaskScheduler taskScheduler;
+
+  private final Set<String> listenersKey;
+
+  private final NacosContextRefresher contextRefresher;
+
+  public LabelRouterConfigListener(NacosContextRefresher contextRefresher, Set<String> listenersKey) {
+    this.listenersKey = new HashSet<>(listenersKey);
+    this.contextRefresher = contextRefresher;
+    this.taskScheduler = buildTaskScheduler();
+  }
+
+  public void schedulerCheckLabelRouterConfig() {
+    taskScheduler.scheduleWithFixedDelay(this::checkLabelRouterConfig, Duration.ofMillis(15000));
+  }
+
+  private void checkLabelRouterConfig() {
+    NacosPropertiesFuzzyQueryService blurQueryService = NacosPropertiesFuzzyQueryService.getInstance();
+    List<PropertyConfigItem> routerProperties = blurQueryService.loadRouterProperties();
+    if (CollectionUtils.isEmpty(routerProperties)) {
+      return;
+    }
+    for (PropertyConfigItem configItem : routerProperties) {
+      String key = NacosPropertySourceRepository.getMapKey(configItem.getDataId(), configItem.getGroup());
+      if (!listenersKey.contains(key)) {
+        contextRefresher.registerAddRouterConfigListener(configItem.getDataId(), configItem.getGroup());
+        listenersKey.add(key);
+      }
+    }
+  }
+
+  private ThreadPoolTaskScheduler buildTaskScheduler() {
+    ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+    taskScheduler.setBeanName("Nacos-Router-Config-Listener-Scheduler");
+    taskScheduler.initialize();
+    return taskScheduler;
+  }
+}

--- a/spring-cloud-huawei-nacos/spring-cloud-huawei-nacos-config/src/main/java/com/huaweicloud/nacos/config/client/LabelRouterConfigListener.java
+++ b/spring-cloud-huawei-nacos/spring-cloud-huawei-nacos-config/src/main/java/com/huaweicloud/nacos/config/client/LabelRouterConfigListener.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.core.env.Environment;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.CollectionUtils;
 
@@ -35,14 +36,19 @@ public class LabelRouterConfigListener {
 
   private final NacosContextRefresher contextRefresher;
 
-  public LabelRouterConfigListener(NacosContextRefresher contextRefresher, Set<String> listenersKey) {
+  private final Environment env;
+
+  public LabelRouterConfigListener(NacosContextRefresher contextRefresher, Set<String> listenersKey, Environment env) {
     this.listenersKey = new HashSet<>(listenersKey);
     this.contextRefresher = contextRefresher;
+    this.env = env;
     this.taskScheduler = buildTaskScheduler();
   }
 
   public void schedulerCheckLabelRouterConfig() {
-    taskScheduler.scheduleWithFixedDelay(this::checkLabelRouterConfig, Duration.ofMillis(15000));
+    String checkRouterConfigDelayTime = "spring.cloud.nacos.check.router.config.delay.time";
+    taskScheduler.scheduleWithFixedDelay(this::checkLabelRouterConfig, Duration.ofMillis(env.getProperty(
+        checkRouterConfigDelayTime, long.class, 30000L)));
   }
 
   private void checkLabelRouterConfig() {


### PR DESCRIPTION
配合CSE平台实现nacos自动灰度能力场景：
当客户端先启动时，平台部署服务端并下发路由配置至nacos配置中心，此时客户端无法加载到该路由配置，因为客户端启动时没有该配置的dataId监听