### PR TITLE
[#1368] add flag control graceful invalid call service-center api

### DIFF
--- a/spring-cloud-huawei-nacos/spring-cloud-huawei-nacos-discovery/src/main/java/com/huaweicloud/nacos/discovery/graceful/NacosGracefulEndpoint.java
+++ b/spring-cloud-huawei-nacos/spring-cloud-huawei-nacos-discovery/src/main/java/com/huaweicloud/nacos/discovery/graceful/NacosGracefulEndpoint.java
@@ -60,7 +60,7 @@ public class NacosGracefulEndpoint {
       nacosAutoServiceRegistration.setRegistryEnabled(false);
       return;
     }
-    LOGGER.warn("operation is not allowed, status: " + status + ", registration_enabled: "
+    LOGGER.info("operation is not allowed, status: " + status + ", registration_enabled: "
         + nacosAutoServiceRegistration.isEnabled());
   }
 }

--- a/spring-cloud-huawei-nacos/spring-cloud-huawei-nacos-discovery/src/main/java/com/huaweicloud/nacos/discovery/registry/NacosAutoServiceRegistration.java
+++ b/spring-cloud-huawei-nacos/spring-cloud-huawei-nacos-discovery/src/main/java/com/huaweicloud/nacos/discovery/registry/NacosAutoServiceRegistration.java
@@ -88,7 +88,7 @@ public class NacosAutoServiceRegistration extends AbstractAutoServiceRegistratio
   }
 
   @Override
-  protected boolean isEnabled() {
+  public boolean isEnabled() {
     return this.registryEnabled;
   }
 

--- a/spring-cloud-huawei-nacos/spring-cloud-huawei-nacos-discovery/src/main/java/com/huaweicloud/nacos/discovery/registry/NacosServiceRegistry.java
+++ b/spring-cloud-huawei-nacos/spring-cloud-huawei-nacos-discovery/src/main/java/com/huaweicloud/nacos/discovery/registry/NacosServiceRegistry.java
@@ -126,6 +126,7 @@ public class NacosServiceRegistry implements ServiceRegistry<Registration> {
         serviceManager.getNamingService().deregisterInstance(serviceId, group, registration.getHost(),
             registration.getPort(), nacosDiscoveryProperties.getClusterName());
         successCount++;
+        LOGGER.info("nacos de-register {} {}:{} finished", serviceId, instance.getIp(), instance.getPort());
       } catch (Exception e) {
         LOGGER.error("de-register service [{}] from Nacos Server [{}] failed.", registration.getServiceId(),
             serviceManager.getServerAddr(), e);

--- a/spring-cloud-huawei-service-engine/service-engine-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/graceful/ServicecombGracefulEndpoint.java
+++ b/spring-cloud-huawei-service-engine/service-engine-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/graceful/ServicecombGracefulEndpoint.java
@@ -49,21 +49,22 @@ public class ServicecombGracefulEndpoint {
     if (StringUtils.isEmpty(status)
         || StringUtils.isEmpty(serviceCombRegistration.getMicroserviceInstance().getServiceId())
         || StringUtils.isEmpty(serviceCombRegistration.getMicroserviceInstance().getInstanceId())) {
+      LOGGER.info("operation is not allowed, status is null or registration is not ok.");
       return;
     }
-    if (isOperationAllow(status)) {
+    if (GovernanceProperties.GRASEFUL_STATUS_UPPER.equalsIgnoreCase(status)
+        && MicroserviceInstanceStatus.DOWN == serviceCombRegistration.getMicroserviceInstance().getStatus()) {
       serviceCombServiceRegistry.setStatus(serviceCombRegistration, status.toUpperCase());
-      LOGGER.warn("servicecomb graceful update status success, status: " + status);
+      LOGGER.info("servicecomb graceful update status success, status: " + status);
       return;
     }
-    LOGGER.warn("operation is not allowed, status: " + status + ", instanceStatus: "
+    if (GovernanceProperties.GRASEFUL_STATUS_DOWN.equalsIgnoreCase(status)
+        && MicroserviceInstanceStatus.UP == serviceCombRegistration.getMicroserviceInstance().getStatus()) {
+      serviceCombServiceRegistry.setStatus(serviceCombRegistration, status.toUpperCase());
+      LOGGER.info("servicecomb graceful update status success, status: " + status);
+      return;
+    }
+    LOGGER.info("operation is not allowed, status: " + status + ", instanceStatus: "
         + serviceCombRegistration.getMicroserviceInstance().getStatus());
-  }
-
-  private boolean isOperationAllow(String status) {
-    return (GovernanceProperties.GRASEFUL_STATUS_UPPER.equalsIgnoreCase(status)
-        && MicroserviceInstanceStatus.DOWN == serviceCombRegistration.getMicroserviceInstance().getStatus())
-        || (GovernanceProperties.GRASEFUL_STATUS_DOWN.equalsIgnoreCase(status)
-        && MicroserviceInstanceStatus.UP == serviceCombRegistration.getMicroserviceInstance().getStatus());
   }
 }

--- a/spring-cloud-huawei-service-engine/service-engine-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/graceful/ServicecombGracefulEndpoint.java
+++ b/spring-cloud-huawei-service-engine/service-engine-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/graceful/ServicecombGracefulEndpoint.java
@@ -53,6 +53,7 @@ public class ServicecombGracefulEndpoint {
     }
     if (isOperationAllow(status)) {
       serviceCombServiceRegistry.setStatus(serviceCombRegistration, status.toUpperCase());
+      LOGGER.warn("servicecomb graceful update status success, status: " + status);
       return;
     }
     LOGGER.warn("operation is not allowed, status: " + status + ", instanceStatus: "

--- a/spring-cloud-huawei-service-engine/service-engine-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/registry/ServiceCombServiceRegistry.java
+++ b/spring-cloud-huawei-service-engine/service-engine-discovery/src/main/java/com/huaweicloud/servicecomb/discovery/registry/ServiceCombServiceRegistry.java
@@ -148,6 +148,7 @@ public class ServiceCombServiceRegistry implements
     try {
       serviceCenterClient.updateMicroserviceInstanceStatus(registration.getMicroserviceInstance().getServiceId(),
           registration.getMicroserviceInstance().getInstanceId(), MicroserviceInstanceStatus.valueOf(status));
+      registration.getMicroserviceInstance().setStatus(MicroserviceInstanceStatus.valueOf(status));
     } catch (OperationException e) {
       LOGGER.error("setStatus failed", e);
     }


### PR DESCRIPTION
servicecomb引擎场景：
1、由于spring加载bean是无序的，某些场景服务端口就绪了，但是微服务未注册，此时实例更新不成功。
2、上线脚本存在问题时，有可能多次请求更新实例状态为UP的情况，给服务端造成不必要的压力。
nacos场景：
上线脚本存在问题时，有可能多次请求更新实例状态为UP的情况，给服务端造成不必要的压力。